### PR TITLE
Test Delta for expanded queries

### DIFF
--- a/v7.x/DeepUpdateTests/DeepUpdateTests/Controllers/CustomersController.cs
+++ b/v7.x/DeepUpdateTests/DeepUpdateTests/Controllers/CustomersController.cs
@@ -1,5 +1,7 @@
 using DeepUpdateTests.Models;
 using Microsoft.AspNet.OData;
+using Microsoft.AspNet.OData.Query;
+using Microsoft.AspNet.OData.Routing;
 using Microsoft.AspNetCore.Mvc;
 
 namespace DeepUpdateTests.Controllers
@@ -16,7 +18,7 @@ namespace DeepUpdateTests.Controllers
                     {
                         Name = "Jonier",
                       //  Order = new Order { Title = "104m" },
-                        Orders = Enumerable.Range(0, 2).Select(e => new Order { Title = "abc" + e, Amount = 100 + e }).ToArray()
+                        Orders = Enumerable.Range(0, 2).Select(e => new Order { Title = "abc" + e, Amount = 100 + e }).ToList()
                     },
                     new Customer
                     {
@@ -28,7 +30,7 @@ namespace DeepUpdateTests.Controllers
                         //    new Address { City = "Re4d", Street = "51 NE"},
                         //},
                         //Order = new Order { Title = "Zhang" },
-                        Orders = Enumerable.Range(0, 2).Select(e => new Order { Title = "xyz" + e, Amount = 200 + e }).ToArray()
+                        Orders = Enumerable.Range(0, 2).Select(e => new Order { Title = "xyz" + e, Amount = 200 + e, List = new List<ListItem> () {new ListItem { isComplete = true } } }).ToList()
                     },
                     new Customer
                     {
@@ -40,7 +42,7 @@ namespace DeepUpdateTests.Controllers
                         //    new Address { City = "R4d", Street = "546 AVE"},
                         //},
                         //Order = new Order { Title = "Jichan" },
-                        Orders = Enumerable.Range(0, 2).Select(e => new Order { Title = "ijk" + e, Amount = 300 + e }).ToArray()
+                        Orders = Enumerable.Range(0, 2).Select(e => new Order { Title = "ijk" + e, Amount = 300 + e }).ToList()
                     },
                 };
         }
@@ -100,6 +102,17 @@ namespace DeepUpdateTests.Controllers
             return Ok(changeItemsInOrders);
 
             // return Ok(_customers.FirstOrDefault(c => c.Id == key));
+        }
+
+        [HttpGet]
+        [ODataRoute("Customers({customerId})/orders")]
+        public IActionResult GetOrdersForCustomer([FromODataUri] string customerId, ODataQueryOptions<Order> options)
+        {
+            // handle read
+            var orders = _customers.SelectMany(c => c.Orders);
+            IQueryable<Order> queryOrders = orders.AsQueryable();
+            options.ApplyTo(queryOrders);
+            return Ok(queryOrders);
         }
 
         /// <summary>

--- a/v7.x/DeepUpdateTests/DeepUpdateTests/DeepUpdateTests.http
+++ b/v7.x/DeepUpdateTests/DeepUpdateTests/DeepUpdateTests.http
@@ -11,6 +11,14 @@ GET {{DeepUpdateTests_HostAddress}}/weatherforecast
 GET {{DeepUpdateTests_HostAddress}}/odata/Customers
 
 ###
+GET {{DeepUpdateTests_HostAddress}}/odata/Customers(1)/orders?$expand=list
+
+###
+# We are looking to support delta on this query with expanded collection navigation property
+# Expect the response to have only changed properties for Checklist and not entire checklist collection object
+GET {{DeepUpdateTests_HostAddress}}/odata/Customers(1)/orders?$expand=list&deltaToken=abcd
+
+###
 # Be noted: If you remove the 'OData-Version' header or version as 4.0, the delta kinds of Orders are all 'entry/entity'
 #           If you have the 'OData-Version' header, the delta kinds of Orders are 'Entry,DeletedEntry,Entry'
 PATCH {{DeepUpdateTests_HostAddress}}/odata/Customers(1)

--- a/v7.x/DeepUpdateTests/DeepUpdateTests/Models/EdmModelBuilder.cs
+++ b/v7.x/DeepUpdateTests/DeepUpdateTests/Models/EdmModelBuilder.cs
@@ -14,6 +14,7 @@ namespace DeepUpdateTests.Models
                 var builder = new ODataConventionModelBuilder();
                 builder.EntitySet<Customer>("Customers");
                 builder.EntitySet<Order>("Orders");
+                builder.EntityType<ListItem>();
 
                 _edmModel = builder.GetEdmModel();
             }
@@ -28,7 +29,7 @@ namespace DeepUpdateTests.Models
 
         public string Name { get; set; }
 
-        public virtual Order[] Orders { get; set; }
+        public virtual IList<Order> Orders { get; set; }
     }
 
     public class Order
@@ -38,5 +39,15 @@ namespace DeepUpdateTests.Models
         public int Amount { get; set; }
 
         public string Title { get; set; }
+
+        [Contained]
+        public virtual IList<ListItem> List { get; set; }
+    }
+
+    public class ListItem
+    {
+        public int Id { get; set; }
+
+        public bool isComplete { get; set; }
     }
 }


### PR DESCRIPTION
Added a test and an API for querying **Orders** in **Customer** model with the **List** collection-valued navigation property expanded.
GET Customers('customerId')/Orders?$expand=list
added a test for the above query as well.

ASK:
I would like to understand how delta works for this query,
GET Customers('customerId')/Orders?$expand=list&deltaToken=abcd

We expect the response to have only changed properties for List and not entire list collection object.
However when I try to set the list value:
```
EdmDeltaEntityObject deltaObject;
EdmChangedObjectCollection listDeltas;
deltaObject.TrySetPropertyValue("list", listDeltas);
```

It fails with below message:
```
ODataException: Cannot transition from state 'NestedResourceInfoWithContent' to state 'DeltaResourceSet'. The only valid actions in state 'NestedResourceInfoWithContent' are to write a resource or a resource set'
```


